### PR TITLE
add make command for gcc >8

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,7 +47,11 @@ SC-IM stands for Spreadsheet Calculator Improvised. :-)
 
 * Run `make`:
 ```
+# gcc8:
     make -C src
+
+# gcc>8:
+	make CC='gcc -fcommon' -C src
 ```
 
 * Optional: You can install the binary `sc-im` in your system by typing with a privileged user:


### PR DESCRIPTION
I had problems with building sc-im and looked how it's done in the AUR. Found out that an additional flag is needed to build it.

according to https://aur.archlinux.org/packages/sc-im/
the original make command doesn't work with gcc >8 anymore.
It needs the `CC='gcc -fcommon'` flag for gcc 9.